### PR TITLE
Fix Path Concatenation & Add Folder Creation

### DIFF
--- a/Cassette/CASFileObjectQueue.h
+++ b/Cassette/CASFileObjectQueue.h
@@ -21,12 +21,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Initializes an @c CASFileObjectQueue with a file in the application's Library directory,
  * returning nil if there was an error.
+ * Note: Intermediate directories will not be created, create containing directory before initializing.
  */
 - (nullable instancetype)initWithRelativePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Initializes an @c CASFileObjectQueue with a file at the specified path,
  * returning nil if there was an error.
+ * Note: Intermediate directories will not be created, create containing directory before initializing.
  */
 - (nullable instancetype)initWithAbsolutePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error;
 

--- a/Cassette/CASFileObjectQueue.m
+++ b/Cassette/CASFileObjectQueue.m
@@ -27,7 +27,7 @@
 
 - (instancetype)initWithRelativePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error {
     NSArray<NSString *> *directoryPaths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
-    NSString *absolutePath = [NSString stringWithFormat:@"%@/%@", directoryPaths[0], filePath];
+    NSString *absolutePath = [directoryPaths[0] stringByAppendingPathComponent:filePath];
     return [self initWithAbsolutePath:absolutePath error:error];
 }
 

--- a/CassetteTests/CASQueueFileTests.m
+++ b/CassetteTests/CASQueueFileTests.m
@@ -25,7 +25,7 @@
     CASQueueFile *queueFile = [CASQueueFile queueFileWithPath:[NSString stringWithFormat:@"%@/CASQueueFileTests-storage", NSTemporaryDirectory()]
                                                               error:&error];
     if (error != nil) {
-        XCTFail(@"CASQueueFile could not be initialized.");
+        XCTFail(@"CASQueueFile could not be initialized. error: %@", error);
     }
     self.queueFile = queueFile;
 }


### PR DESCRIPTION
1. Avoids possibilty of double `//` in path when
concating relative path to library folder path,
by using `stringByAppendingPathComponent`.
2. Create folders and intermediary folder now
if they don't exist for file queue path.
3. More unit tests around various relative
and absolute path inputs.