### PR TITLE
Propagate I/O errors from filesystem and serialization failures

### DIFF
--- a/CASSampleApp/MainViewController.m
+++ b/CASSampleApp/MainViewController.m
@@ -51,13 +51,19 @@
     NSString *result = self.inputField.text;
     NSNumber *number = [numberFormatter numberFromString:result];
     if (number != nil) {
-        [self.queue add:number];
+        NSError *error;
+        if (![self.queue add:number error:&error]) {
+            NSLog(@"Failed to add number: %@ error: %@", number, error);
+        }
     }
     [self refreshHeadElementLabel];
 }
 
 - (IBAction)tapPopButton:(__unused id)sender {
-    [self.queue pop];
+    NSError *error;
+    if (![self.queue pop:1 error:&error]) {
+        NSLog(@"Failed to pop, error: %@", error);
+    }
     [self refreshHeadElementLabel];
 }
 
@@ -66,7 +72,12 @@
 }
 
 - (void)refreshHeadElementLabel {
-    NSNumber *number = [self.queue peek];
+    NSError *error;
+    NSArray<NSNumber *> *numbers = [self.queue peek:1 error:&error];
+    if (!numbers) {
+        NSLog(@"Failed to peek, error: %@", error);
+    }
+    NSNumber *number = numbers.firstObject;
     if (number == nil) {
         self.headElementLabel.text = @"empty";
     } else {

--- a/Cassette/CASInMemoryObjectQueue.m
+++ b/Cassette/CASInMemoryObjectQueue.m
@@ -25,31 +25,33 @@
     return self;
 }
 
-- (void)add:(id)data {
+- (BOOL)add:(id)data error:(NSError * __autoreleasing * _Nullable)error {
     [self.inMemoryStorage addObject:data];
+    return YES;
 }
 
 - (NSUInteger)size {
     return self.inMemoryStorage.count;
 }
 
--(NSArray *)peek:(NSUInteger)amount {
+- (NSArray<id> * _Nullable)peek:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error {
     // Clamp number of elements we read down to the size in case @c amount is larger
     NSUInteger actualAmountToRetrieve = MIN(amount, self.size);
     return [self.inMemoryStorage subarrayWithRange:NSMakeRange(0, actualAmountToRetrieve)];
 }
 
-- (void)pop:(NSUInteger)amount {
+- (BOOL)pop:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error {
     if (amount >= self.size) {
-        [self clear];
-        return;
+        return [self clearAndReturnError:error];
     }
 
     [self.inMemoryStorage removeObjectsInRange:NSMakeRange(0, amount)];
+    return YES;
 }
 
-- (void)clear {
+- (BOOL)clearAndReturnError:(NSError * __autoreleasing * _Nullable)error {
     [self.inMemoryStorage removeAllObjects];
+    return YES;
 }
 
 @end

--- a/Cassette/CASObjectQueue.h
+++ b/Cassette/CASObjectQueue.h
@@ -20,8 +20,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Adds an element to the end of the queue.
+ *
+ * Please use the API @c add:error: instead.
  */
-- (void)add:(T)data;
+- (void)add:(T)data __attribute__((deprecated("Use -add:error: instead.")));
+
+/**
+ * Adds an element to the end of the queue.
+ * Returns YES on success. On failure, returns NO and sets *error to the error.
+ */
+- (BOOL)add:(T)data error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Returns the number of elements in this queue.
@@ -36,31 +44,63 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns the head of the queue, or nil if the queue is empty. Does not modify the
  * queue.
+ *
+ * Please use the API @c peek:error: instead.
  */
-- (nullable T)peek;
+- (nullable T)peek __attribute__((deprecated("Use -peek:error: instead.")));
 
 /**
  * Reads up to the specified amount of entries from the head of the queue without removing
  * the entries.
  * If the queue's @c size() is less than the amount specified, then only @c size() entries
  * are read.
+ *
+ * Please use the API @c peek:error: instead.
  */
-- (NSArray<T> *)peek:(NSUInteger)amount;
+- (NSArray<T> *)peek:(NSUInteger)amount __attribute__((deprecated("Use -peek:error: instead.")));
+
+/**
+ * Reads up to the specified amount of entries from the head of the queue without removing
+ * the entries.
+ * If the queue's @c size() is less than the amount specified, then only @c size() entries
+ * are read.
+ *
+ * Returns the items read on success. On failure, returns nil and sets *error to the error.
+ */
+- (NSArray<T> * _Nullable)peek:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Removes the head of the queue.
+ *
+ * Please use the API @c pop:error: instead.
  */
-- (void)pop;
+- (void)pop __attribute__((deprecated("Use -pop:error: instead.")));;
 
 /**
  * Removes the specified amount of entries from the head of the queue.
+ *
+ * Please use the API @c pop:error: instead.
  */
-- (void)pop:(NSUInteger)amount;
+- (void)pop:(NSUInteger)amount __attribute__((deprecated("Use -peek:error: instead.")));
+
+/**
+ * Removes the specified amount of entries from the head of the queue.
+ * Returns YES on success. On failure, returns NO and sets *error to the error.
+ */
+- (BOOL)pop:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Clears this queue. Truncates the file to the initial size.
+ *
+ * Please use the API @c clearAndReturnError: instead.
  */
-- (void)clear;
+- (void)clear __attribute__((deprecated("Use -clearAndReturnError: instead.")));;
+
+/**
+ * Clears this queue. Truncates the file to the initial size.
+ * Returns YES on success. On failure, returns NO and sets *error to the error.
+ */
+- (BOOL)clearAndReturnError:(NSError * __autoreleasing * _Nullable)error;
 
 @end
 

--- a/Cassette/CASObjectQueue.m
+++ b/Cassette/CASObjectQueue.m
@@ -12,9 +12,14 @@
 
 @implementation CASObjectQueue
 
-- (void)add:(__unused id)data {
+- (void)add:(id)data {
+    [self add:data error:NULL];
+}
+
+- (BOOL)add:(__unused id)data error:(__unused NSError * __autoreleasing * _Nullable)error {
     [NSException raise:NSInternalInconsistencyException
                 format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
+    return NO;
 }
 
 - (NSUInteger)size {
@@ -28,30 +33,39 @@
 }
 
 - (id)peek {
-    NSArray<id> *elements = [self peek:1];
-    if (elements.count > 0) {
-        return elements[0];
-    }
+    return [self peek:1 error:NULL].firstObject;
+}
+
+- (NSArray<id> *)peek:(NSUInteger)amount {
+    return [self peek:amount error:NULL] ?: @[];
+}
+
+- (NSArray<id> * _Nullable)peek:(__unused NSUInteger)amount error:(__unused NSError * __autoreleasing * _Nullable)error {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
     return nil;
 }
 
-- (NSArray<id> *)peek:(__unused NSUInteger)amount {
-    [NSException raise:NSInternalInconsistencyException
-                format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
-    return @[];
-}
-
 - (void)pop {
-    [self pop:1];
+    [self pop:1 error:NULL];
 }
 
-- (void)pop:(__unused NSUInteger)amount {
+- (void)pop:(NSUInteger)amount {
+    [self pop:amount error:NULL];
+}
+
+- (BOOL)pop:(__unused NSUInteger)amount error:(__unused NSError * __autoreleasing * _Nullable)error {
     [NSException raise:NSInternalInconsistencyException
                 format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
+    return NO;
 }
 
 - (void)clear {
-    [self pop:self.size];
+    [self clearAndReturnError:NULL];
+}
+
+- (BOOL)clearAndReturnError:(NSError * __autoreleasing * _Nullable)error {
+    return [self pop:self.size error:error];
 }
 
 @end

--- a/Cassette/CASQueueFile.h
+++ b/Cassette/CASQueueFile.h
@@ -36,8 +36,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Adds an element to the end of the queue.
+ *
+ * Please use the API @c add:error: instead.
  */
-- (void)add:(NSData *)data;
+- (void)add:(NSData *)data __attribute__((deprecated("Use -add:error: instead.")));
+
+/**
+ * Adds an element to the end of the queue.
+ * Returns YES on success. On failure, returns NO and sets *error to the error.
+ */
+- (BOOL)add:(NSData *)data error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Returns the number of elements in this queue.
@@ -54,18 +62,46 @@ NS_ASSUME_NONNULL_BEGIN
  * the entries.
  * If the queue's @c size() is less than the amount specified, then only @c size() entries
  * are read.
+ *
+ * Please use the API @c peek:error: instead.
  */
-- (NSArray<NSData *> *)peek:(NSUInteger)amount;
+- (NSArray<NSData *> *)peek:(NSUInteger)amount __attribute__((deprecated("Use peek:error: instead.")));
+
+/**
+ * Reads up to the specified amount of entries from the head of the queue without removing
+ * the entries.
+ * If the queue's @c size() is less than the amount specified, then only @c size() entries
+ * are read.
+ *
+ * Returns the items read on success. On failure, returns nil and sets *error to the error.
+ */
+- (nullable NSArray<NSData *> *)peek:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Removes the specified amount of entries from the head of the queue.
+ *
+ * Please use the API @c pop:error: instead.
  */
-- (void)pop:(NSUInteger)amount;
+- (void)pop:(NSUInteger)amount __attribute__((deprecated("Use -pop:error: instead.")));
+
+/**
+ * Removes the specified amount of entries from the head of the queue.
+ * Returns YES on success. On failure, returns NO and sets *error to the error.
+ */
+- (BOOL)pop:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error;
 
 /**
  * Clears this queue. Truncates the file to the initial size.
+ *
+ * Please use the API @c clearAndReturnError: instead.
  */
-- (void)clear;
+- (void)clear __attribute__((deprecated("Use -clearAndReturnError: instead.")));
+
+/**
+ * Clears this queue. Truncates the file to the initial size.
+ * Returns YES on success. On failure, returns NO and sets *error to the error.
+ */
+- (BOOL)clearAndReturnError:(NSError * __autoreleasing * _Nullable)error;
 
 @end
 

--- a/Cassette/CASQueueFile.m
+++ b/Cassette/CASQueueFile.m
@@ -97,7 +97,47 @@ static NSUInteger const ElementHeaderLength = 4;
         return nil;
     }
 
-    return [[self alloc] initWithPath:path forManager:fileManager];
+    NSFileHandle *fileHandle = [NSFileHandle fileHandleForUpdatingURL:[NSURL fileURLWithPath:path]
+                                                                error:error];
+    if (!fileHandle) {
+        return nil;
+    }
+    NSData *buffer;
+
+    if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+        if (![fileHandle seekToOffset:0 error:error]) {
+            return nil;
+        }
+        buffer = [fileHandle readDataUpToLength:QueueFileHeaderLength error:error];
+        if (!buffer) {
+            return nil;
+        }
+    } else {
+        [fileHandle seekToFileOffset:0];
+        buffer = [fileHandle readDataOfLength:QueueFileHeaderLength];
+    }
+
+    NSUInteger fileLength = readUnsignedInt(buffer, 0);
+    NSUInteger elementCount = readUnsignedInt(buffer, 4);
+    NSUInteger firstObjectOffset = readUnsignedInt(buffer, 8);
+    NSUInteger lastObjectOffset = readUnsignedInt(buffer, 12);
+
+    CASQueueFile *result = [[self alloc] initWithCommitFilePath:commitFilePath
+                                                     forManager:fileManager
+                                                     fileHandle:fileHandle
+                                                     fileLength:fileLength
+                                                   elementCount:elementCount];
+    CASQueueFileElement *firstElement = [result readElement:firstObjectOffset error:error];
+    if (!firstElement) {
+        return nil;
+    }
+    CASQueueFileElement *lastElement = [result readElement:lastObjectOffset error:error];
+    if (!lastElement) {
+        return nil;
+    }
+    result.first = firstElement;
+    result.last = lastElement;
+    return result;
 }
 
 /**
@@ -152,40 +192,33 @@ static NSUInteger const ElementHeaderLength = 4;
     }
 }
 
-- (instancetype)initWithPath:(NSString *)filePath
-                  forManager:(NSFileManager *)fileManager {
+- (instancetype)initWithCommitFilePath:(NSString *)commitFilePath
+                            forManager:(NSFileManager *)fileManager
+                            fileHandle:(NSFileHandle *)fileHandle
+                            fileLength:(NSUInteger)fileLength
+                          elementCount:(NSUInteger)elementCount {
     if (self = [super init]) {
-        _commitFilePath = commitFilePathForFile(filePath);
+        _commitFilePath = [commitFilePath copy];
         _fileManager = fileManager;
-        _fileHandle = [NSFileHandle fileHandleForUpdatingAtPath:filePath];
+        _fileHandle = fileHandle;
         _buffer = [NSMutableData dataWithLength:QueueFileHeaderLength];
-
-        // Now that our main properties are set up, let's set up some fast access variables.
-        [self parseHeaderForFastAccessVariables];
+        _fileLength = fileLength;
+        _elementCount = elementCount;
     }
     return self;
-}
-
-/**
- * Read the data stored in the header into instance variables.
- */
-- (void)parseHeaderForFastAccessVariables {
-    [self.fileHandle seekToFileOffset:0];
-    NSData *buffer = [self.fileHandle readDataOfLength:QueueFileHeaderLength];
-
-    self.fileLength = readUnsignedInt(buffer, 0);
-    self.elementCount = readUnsignedInt(buffer, 4);
-    NSUInteger firstObjectOffset = readUnsignedInt(buffer, 8);
-    NSUInteger lastObjectOffset = readUnsignedInt(buffer, 12);
-
-    self.first = [self readElement:firstObjectOffset];
-    self.last = [self readElement:lastObjectOffset];
 }
 
 #pragma mark - Public API
 
 - (void)add:(NSData *)data {
-    [self expandIfNecessary:data.length];
+    [self add:data error:NULL];
+}
+
+- (BOOL)add:(NSData *)data
+      error:(NSError * __autoreleasing * _Nullable)error {
+    if (![self expandIfNecessary:data.length error:error]) {
+        return NO;
+    }
 
     // Insert a new element after the current last element.
     BOOL wasEmpty = self.isEmpty;
@@ -194,17 +227,24 @@ static NSUInteger const ElementHeaderLength = 4;
 
     // Write element length.
     writeInt(self.buffer, 0, (uint32_t) data.length);
-    [self ringWriteAtPosition:newLastElement.position buffer:self.buffer];
+    if (![self ringWriteAtPosition:newLastElement.position buffer:self.buffer error:error]) {
+        return NO;
+    }
 
     // Write element's data.
-    [self ringWriteAtPosition:newLastElement.position + ElementHeaderLength buffer:data];
+    if (![self ringWriteAtPosition:newLastElement.position + ElementHeaderLength buffer:data error:error]) {
+        return NO;
+    }
 
     // Commit the addition. If wasEmpty, first == last.
     NSUInteger firstPosition = wasEmpty ? newLastElement.position : self.first.position;
-    [self writeHeader:_fileLength
-         elementCount:_elementCount + 1
-        firstPosition:firstPosition
-         lastPosition:newLastElement.position];
+    if (![self writeHeader:_fileLength
+              elementCount:_elementCount + 1
+             firstPosition:firstPosition
+              lastPosition:newLastElement.position
+                     error:error]) {
+        return NO;
+    }
     self.last = newLastElement;
     self.elementCount++;
 
@@ -212,6 +252,8 @@ static NSUInteger const ElementHeaderLength = 4;
     if (wasEmpty) {
         self.first = self.last;
     }
+
+    return YES;
 }
 
 - (NSUInteger)size {
@@ -223,6 +265,10 @@ static NSUInteger const ElementHeaderLength = 4;
 }
 
 - (NSArray<NSData *> *)peek:(NSUInteger)amount {
+    return [self peek:amount error:NULL] ?: @[];
+}
+
+- (nullable NSArray<NSData *> *)peek:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error {
     // Clamp number of elements we read down to the size in case @c amount is larger
     amount = MIN(amount, self.elementCount);
     NSUInteger position = self.first.position;
@@ -230,8 +276,14 @@ static NSUInteger const ElementHeaderLength = 4;
 
     for (NSUInteger i = 0; i < amount; i++) {
         // Read element from storage
-        CASQueueFileElement *current = [self readElement:position];
-        NSData *data = [self ringReadAtPosition:current.position + ElementHeaderLength count:current.length];
+        CASQueueFileElement *current = [self readElement:position error:error];
+        if (!current) {
+            return nil;
+        }
+        NSData *data = [self ringReadAtPosition:current.position + ElementHeaderLength count:current.length error:error];
+        if (!data) {
+            return nil;
+        }
 
         // cache the result
         [elements addObject:data];
@@ -244,15 +296,18 @@ static NSUInteger const ElementHeaderLength = 4;
 }
 
 - (void)pop:(NSUInteger)amount {
+    [self pop:amount error:NULL];
+}
+
+- (BOOL)pop:(NSUInteger)amount error:(NSError * __autoreleasing * _Nullable)error {
     // Base case: Nothing to do if we have no elements
     if (self.isEmpty || amount == 0) {
-        return;
+        return YES;
     }
 
     // Optimize for clear call when possible since it is less expensive
     if (amount >= self.elementCount) {
-        [self clear];
-        return;
+        return [self clearAndReturnError:error];
     }
 
     NSUInteger eraseStartPosition = self.first.position;
@@ -264,41 +319,60 @@ static NSUInteger const ElementHeaderLength = 4;
     for (NSUInteger i = 0; i < amount; i++) {
         totalLengthToErase += ElementHeaderLength + newFirstLength;
         newFirstPosition = [self wrapPosition:newFirstPosition + ElementHeaderLength + newFirstLength];
-        NSData *buffer = [self ringReadAtPosition:newFirstPosition count:ElementHeaderLength];
+        NSData *buffer = [self ringReadAtPosition:newFirstPosition count:ElementHeaderLength error:error];
+        if (!buffer) {
+            return NO;
+        }
         newFirstLength = readUnsignedInt(buffer, 0);
     }
 
     // Commit the header and reassign pertinent in-memory variables
-    [self writeHeader:self.fileLength
-         elementCount:self.elementCount - amount
-        firstPosition:newFirstPosition
-         lastPosition:self.last.position];
+    if (![self writeHeader:self.fileLength
+              elementCount:self.elementCount - amount
+             firstPosition:newFirstPosition
+              lastPosition:self.last.position
+                     error:error]) {
+        return NO;
+    }
     self.elementCount -= amount;
     self.first = [[CASQueueFileElement alloc] initAtPosition:newFirstPosition withLength:newFirstLength];
 
     // Zero out the data where the elements were removed
-    [self ringEraseAtPosition:eraseStartPosition length:totalLengthToErase];
+    return [self ringEraseAtPosition:eraseStartPosition length:totalLengthToErase error:error];
 }
 
 - (void)clear {
-    // Reset the header
-    [self writeHeader:QueueFileInitialLength
-         elementCount:0
-        firstPosition:0
-         lastPosition:0];
+    [self clearAndReturnError:NULL];
+}
 
-    // Zero out the data in our file storage
-    NSData *buffer = [NSMutableData dataWithLength:QueueFileInitialLength - QueueFileHeaderLength];
-    [self ringWriteAtPosition:QueueFileHeaderLength buffer:buffer];
+- (BOOL)clearAndReturnError:(NSError * __autoreleasing * _Nullable)error {
+    // Reset the header
+    if (![self writeHeader:QueueFileInitialLength
+              elementCount:0
+             firstPosition:0
+              lastPosition:0
+                     error:error]) {
+        return NO;
+    }
 
     // Reset in-memory variables
     self.elementCount = 0;
     self.first = CASQueueFileElement.null;
     self.last = CASQueueFileElement.null;
+
+   // Zero out the data in our file storage
+    NSData *buffer = [NSMutableData dataWithLength:QueueFileInitialLength - QueueFileHeaderLength];
+    if (![self ringWriteAtPosition:QueueFileHeaderLength buffer:buffer error:error]) {
+        return NO;
+    }
+
     if (self.fileLength > QueueFileInitialLength) {
-        [self setFile:self.fileHandle toLength:QueueFileInitialLength];
+        if (![self setFile:self.fileHandle toLength:QueueFileInitialLength error:error]) {
+            return NO;
+        }
     }
     self.fileLength = QueueFileInitialLength;
+    return YES;
 }
 
 #pragma mark - Private Helper Functions
@@ -307,11 +381,15 @@ static NSUInteger const ElementHeaderLength = 4;
  * Reads the element stored at the given position in the file, wrapping around
  * if necessary.
  */
-- (CASQueueFileElement *)readElement:(NSUInteger)position {
+- (nullable CASQueueFileElement *)readElement:(NSUInteger)position
+                                        error:(NSError * __autoreleasing * _Nullable)error {
     if (position == 0) {
         return [CASQueueFileElement null];
     }
-    NSData *buffer = [self ringReadAtPosition:position count:ElementHeaderLength];
+    NSData *buffer = [self ringReadAtPosition:position count:ElementHeaderLength error:error];
+    if (!buffer) {
+        return nil;
+    }
     NSUInteger length = readUnsignedInt(buffer, 0);
     return [[CASQueueFileElement alloc] initAtPosition:(NSUInteger)position withLength:length];
 }
@@ -320,22 +398,48 @@ static NSUInteger const ElementHeaderLength = 4;
  * Reads @c count bytes from the given position in the file, wrapping
  * around if necessary.
  */
-- (NSData *)ringReadAtPosition:(NSUInteger)position count:(NSUInteger)count {
+- (nullable NSData *)ringReadAtPosition:(NSUInteger)position count:(NSUInteger)count error:(NSError * __autoreleasing * _Nullable)error {
     position = [self wrapPosition:position];
 
     // Handle the simple case where we don't wrap around
     if (position + count < self.fileLength) {
-        [self.fileHandle seekToFileOffset:position];
-        return [self.fileHandle readDataOfLength:count];
+        if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+            if (![self.fileHandle seekToOffset:position error:error]) {
+                return nil;
+            }
+            return [self.fileHandle readDataUpToLength:count error:error];
+        } else {
+            [self.fileHandle seekToFileOffset:position];
+            return [self.fileHandle readDataOfLength:count];
+        }
     }
 
     // The requested read overlaps the EOF, so we need to read through to the EOF, wrap around, and read the remaining bytes
     NSMutableData *buffer = [NSMutableData dataWithCapacity:count];
     NSUInteger numBytesBeforeEOF = self.fileLength - position;
-    [self.fileHandle seekToFileOffset:position];
-    [buffer appendData:[self.fileHandle readDataOfLength:numBytesBeforeEOF]];
-    [self.fileHandle seekToFileOffset:QueueFileHeaderLength];
-    [buffer appendData:[self.fileHandle readDataOfLength:count - numBytesBeforeEOF]];
+    if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+        if (![self.fileHandle seekToOffset:position error:error]) {
+            return nil;
+        }
+        NSData *dataUntilEOF = [self.fileHandle readDataUpToLength:numBytesBeforeEOF error:error];
+        if (!dataUntilEOF) {
+            return nil;
+        }
+        [buffer appendData:dataUntilEOF];
+        if (![self.fileHandle seekToOffset:QueueFileHeaderLength error:error]) {
+            return nil;
+        }
+        NSData *remainingData = [self.fileHandle readDataUpToLength:count - numBytesBeforeEOF error:error];
+        if (!remainingData) {
+            return nil;
+        }
+        [buffer appendData:remainingData];
+    } else {
+        [self.fileHandle seekToFileOffset:position];
+        [buffer appendData:[self.fileHandle readDataOfLength:numBytesBeforeEOF]];
+        [self.fileHandle seekToFileOffset:QueueFileHeaderLength];
+        [buffer appendData:[self.fileHandle readDataOfLength:count - numBytesBeforeEOF]];
+    }
     return buffer;
 }
 
@@ -343,33 +447,65 @@ static NSUInteger const ElementHeaderLength = 4;
  * Writes buffer to position in file. Automatically wraps write if position is past the end of the file
  * or if buffer overlaps it.
  */
-- (void)ringWriteAtPosition:(NSUInteger)position buffer:(NSData *)buffer {
+- (BOOL)ringWriteAtPosition:(NSUInteger)position buffer:(NSData *)buffer error:(NSError * __autoreleasing * _Nullable)error {
     position = [self wrapPosition:position];
 
     // Handle the simple case where we don't wrap around
     if (position + buffer.length <= self.fileLength) {
-        [self.fileHandle seekToFileOffset:position];
-        [self.fileHandle writeData:buffer];
+        if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+            if (![self.fileHandle seekToOffset:position error:error]) {
+                return NO;
+            }
+            if (![self.fileHandle writeData:buffer error:error]) {
+                return NO;
+            }
+        } else {
+            [self.fileHandle seekToFileOffset:position];
+            [self.fileHandle writeData:buffer];
+        }
     } else {
         // The write overlaps the EOF.
         // # of bytes to write before the EOF.
         NSUInteger numBytesBeforeEOF = _fileLength - position;
-        [self.fileHandle seekToFileOffset:position];
-        [self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0, numBytesBeforeEOF)]];
-        [self.fileHandle seekToFileOffset:QueueFileHeaderLength];
-        [self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0 + numBytesBeforeEOF, buffer.length - numBytesBeforeEOF)]];
+        if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+            if (![self.fileHandle seekToOffset:position error:error]) {
+                return NO;
+            }
+            if (![self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0, numBytesBeforeEOF)] error:error]) {
+                return NO;
+            }
+            if (![self.fileHandle seekToOffset:QueueFileHeaderLength error:error]) {
+                return NO;
+            }
+            if (![self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0 + numBytesBeforeEOF, buffer.length - numBytesBeforeEOF)] error:error]) {
+                return NO;
+            }
+        } else {
+            [self.fileHandle seekToFileOffset:position];
+            [self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0, numBytesBeforeEOF)]];
+            [self.fileHandle seekToFileOffset:QueueFileHeaderLength];
+            [self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0 + numBytesBeforeEOF, buffer.length - numBytesBeforeEOF)]];
+        }
     }
 
     // Flush in-memory changes to permanent storage
-    [self.fileHandle synchronizeFile];
+    if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+        if (![self.fileHandle synchronizeAndReturnError:error]) {
+            return NO;
+        }
+    } else {
+        [self.fileHandle synchronizeFile];
+    }
+
+    return YES;
 }
 
 /**
  * Zeroes out the file starting at @c position until @c length.
  */
-- (void)ringEraseAtPosition:(NSUInteger)position length:(NSUInteger)length {
+- (BOOL)ringEraseAtPosition:(NSUInteger)position length:(NSUInteger)length error:(NSError * __autoreleasing * _Nullable)error {
     NSData *buffer = [NSMutableData dataWithLength:length];
-    [self ringWriteAtPosition:position buffer:buffer];
+    return [self ringWriteAtPosition:position buffer:buffer error:error];
 }
 
 /**
@@ -377,10 +513,11 @@ static NSUInteger const ElementHeaderLength = 4;
  * file. Assumes segment writes are atomic in the underlying file
  * system.
  */
-- (void)writeHeader:(NSUInteger)fileLength
+- (BOOL)writeHeader:(NSUInteger)fileLength
        elementCount:(NSUInteger)elementCount
       firstPosition:(NSUInteger)firstPosition
        lastPosition:(NSUInteger)lastPosition
+              error:(NSError * __autoreleasing * _Nullable)error
 {
     // Write header attributes to in-memory buffer
     writeInt(self.buffer, 0, (uint32_t) fileLength);
@@ -389,21 +526,47 @@ static NSUInteger const ElementHeaderLength = 4;
     writeInt(self.buffer, 12, (uint32_t) lastPosition);
 
     // Create temporary file to not lose the data
-    if (![self.fileManager createFileAtPath:self.commitFilePath
-                                   contents:self.buffer
-                                 attributes:nil]) {
-        CASLOG(@"Could not initialize commit file at path: %@.", self.commitFilePath);
+    if (![self.buffer writeToFile:self.commitFilePath
+                          options:NSDataWritingAtomic
+                            error:error]) {
+        if (error) {
+            CASLOG(@"Could not initialize commit file at path: %@, error: %@", self.commitFilePath, *error);
+        }
+        return NO;
     }
 
     // Write header to file
-    [self.fileHandle seekToFileOffset:0];
-    [self.fileHandle writeData:self.buffer];
-    [self.fileHandle synchronizeFile];
+    if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+        if (![self.fileHandle seekToOffset:0 error:error]) {
+            if (error) {
+                CASLOG(@"Could not seek to beginning of file, error: %@", *error);
+            }
+            return NO;
+        }
+        if (![self.fileHandle writeData:self.buffer error:error]) {
+            if (error) {
+                CASLOG(@"Could not write %zu bytes, error: %@", self.buffer.length, *error);
+            }
+            return NO;
+        }
+        if (![self.fileHandle synchronizeAndReturnError:error]) {
+            if (error) {
+                CASLOG(@"Could not synchronize file, error: %@", *error);
+            }
+            return NO;
+        }
+    } else {
+        [self.fileHandle seekToFileOffset:0];
+        [self.fileHandle writeData:self.buffer];
+        [self.fileHandle synchronizeFile];
+    }
 
     // Remove the temporary file since it's no longer necessary
-    if (![self.fileManager removeItemAtPath:self.commitFilePath error:nil]) {
-        CASLOG(@"Could not remove commit file at path: %@.", self.commitFilePath);
+    NSError *removeError;
+    if (![self.fileManager removeItemAtPath:self.commitFilePath error:&removeError]) {
+        CASLOG(@"Could not remove commit file at path: %@, error: %@", self.commitFilePath, removeError);
     }
+    return YES;
 }
 
 /**
@@ -416,14 +579,17 @@ static NSUInteger const ElementHeaderLength = 4;
 /**
  * If necessary, expands the file to accommodate an additional element of the
  * given length.
+ *
+ * Returns YES on success. On failure, returns NO and sets *error.
  */
-- (void)expandIfNecessary:(NSUInteger)elementLength {
+- (BOOL)expandIfNecessary:(NSUInteger)elementLength
+                    error:(NSError * __autoreleasing * _Nullable)error {
     NSUInteger numBytesRequested = ElementHeaderLength + elementLength;
     NSUInteger remainingBytes = [self remainingBytes];
 
     // The file has enough space to accomodate the new element. Return early
     if (remainingBytes >= numBytesRequested) {
-        return;
+        return YES;
     }
 
     // Resize the file to accomodate the new element.
@@ -438,7 +604,9 @@ static NSUInteger const ElementHeaderLength = 4;
     } while (remainingBytes < numBytesRequested);
 
     // Actually expand the file
-    [self setFile:self.fileHandle toLength:newFileLength];
+    if (![self setFile:self.fileHandle toLength:newFileLength error:error]) {
+        return NO;
+    }
 
     // Calculate the position of the tail end of the data in the ring buffer
     NSUInteger endOfLastElement = [self wrapPosition:self.last.position + ElementHeaderLength + self.last.length];
@@ -447,35 +615,78 @@ static NSUInteger const ElementHeaderLength = 4;
         // Hard luck. The data wrapped around to the head and is now fragmented due to file expansion.
         // Copy the tail data after the head data to fix and make contiguous.
         NSUInteger count = endOfLastElement - QueueFileHeaderLength;
-        NSData *buffer = [self ringReadAtPosition:QueueFileHeaderLength count:count];
-        [self.fileHandle seekToFileOffset:self.fileLength];
-        [self.fileHandle writeData:buffer];
-        [self ringEraseAtPosition:QueueFileHeaderLength length:count];
+        NSData *buffer = [self ringReadAtPosition:QueueFileHeaderLength count:count error:error];
+        if (!buffer) {
+            return NO;
+        }
+        if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+            if (![self.fileHandle seekToOffset:self.fileLength error:error]) {
+                if (error) {
+                    CASLOG(@"Could not seek to offset %zu, error: %@", self.fileLength, *error);
+                }
+                return NO;
+            }
+            if (![self.fileHandle writeData:buffer error:error]) {
+                if (error) {
+                    CASLOG(@"Could not write %zu bytes, error: %@", buffer.length, *error);
+                }
+                return NO;
+            }
+        } else {
+            [self.fileHandle seekToFileOffset:self.fileLength];
+            [self.fileHandle writeData:buffer];
+        }
+        if (![self ringEraseAtPosition:QueueFileHeaderLength length:count error:error]) {
+            return NO;
+        }
     }
 
     // Update the headers and in-memory variables
     if (self.last.position < self.first.position) {
         NSUInteger newLastPosition = self.fileLength + self.last.position - QueueFileHeaderLength;
-        [self writeHeader:newFileLength
-             elementCount:self.elementCount
-            firstPosition:self.first.position
-             lastPosition:newLastPosition];
+        if (![self writeHeader:newFileLength
+                  elementCount:self.elementCount
+                 firstPosition:self.first.position
+                  lastPosition:newLastPosition
+                         error:error]) {
+            return NO;
+        }
         self.last = [[CASQueueFileElement alloc] initAtPosition:newLastPosition withLength:self.last.length];
     } else {
-        [self writeHeader:newFileLength
-             elementCount:self.elementCount
-            firstPosition:self.first.position
-             lastPosition:self.last.position];
+        if (![self writeHeader:newFileLength
+                  elementCount:self.elementCount
+                 firstPosition:self.first.position
+                  lastPosition:self.last.position
+                         error:error]) {
+            return NO;
+        }
     }
     self.fileLength = newFileLength;
+    return YES;
 }
 
 /**
  * Truncates the specified file to the new length, and commits it to persisted storage.
  */
-- (void)setFile:(NSFileHandle *)fileHandle toLength:(NSUInteger)newLength {
-    [fileHandle truncateFileAtOffset:newLength];
-    [fileHandle synchronizeFile];
+- (BOOL)setFile:(NSFileHandle *)fileHandle toLength:(NSUInteger)newLength error:(NSError * __autoreleasing * _Nullable)error {
+    if (@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)) {
+        if (![fileHandle truncateAtOffset:newLength error:error]) {
+            if (error) {
+                CASLOG(@"Could not truncate to %zu bytes, error: %@", newLength, *error);
+            }
+            return NO;
+        }
+        if (![fileHandle synchronizeAndReturnError:error]) {
+            if (error) {
+                CASLOG(@"Could not synchronize file, error: %@", *error);
+            }
+            return NO;
+        }
+    } else {
+        [fileHandle truncateFileAtOffset:newLength];
+        [fileHandle synchronizeFile];
+    }
+    return YES;
 }
 
 - (NSUInteger)remainingBytes {

--- a/CassetteTests/CASFileObjectQueueTests.m
+++ b/CassetteTests/CASFileObjectQueueTests.m
@@ -42,7 +42,7 @@
 }
 
 - (void)tearDown {
-    [self.queue clear];
+    XCTAssertTrue([self.queue clearAndReturnError:NULL]);
 }
 
 #pragma mark - tests
@@ -78,7 +78,7 @@
                      fullPath,
                      error.localizedDescription);
 
-        [queue add:@(1)];
+        XCTAssertTrue([queue add:@(1) error:NULL]);
     }
 }
 
@@ -112,7 +112,7 @@
                      fullPath,
                      error.localizedDescription);
 
-        [queue add:@(1)];
+        XCTAssertTrue([queue add:@(1) error:NULL]);
     }
 }
 
@@ -120,7 +120,7 @@
     XCTAssertEqual(self.queue.size, 0);
 
     for (NSUInteger i = 0; i < 10; i++) {
-        [self.queue add:@1];
+        XCTAssertTrue([self.queue add:@1 error:NULL]);
     }
 
     XCTAssertEqual(self.queue.size, 10);
@@ -130,30 +130,30 @@
     XCTAssertEqual(self.queue.size, 0);
 
     for (int i = 0; i < 10; i++) {
-        [self.queue add:@1];
+        XCTAssertTrue([self.queue add:@1 error:NULL]);
     }
 
     for (int i = 9; i >= 0; i--) {
-        [self.queue pop];
+        XCTAssertTrue([self.queue pop:1 error:NULL]);
         XCTAssertEqual(self.queue.size, (NSUInteger) i);
     }
 }
 
 - (void)testCorrectElementIsRemovedWhenPopped {
     for (int i = 0; i < 3; i++) {
-        [self.queue add:[NSNumber numberWithInt:i]];
+        XCTAssertTrue([self.queue add:[NSNumber numberWithInt:i] error:NULL]);
     }
 
-    [self.queue pop];
+    XCTAssertTrue([self.queue pop:1 error:NULL]);
 
-    NSArray<NSNumber *> *remainingElements = [self.queue peek:self.queue.size];
+    NSArray<NSNumber *> *remainingElements = [self.queue peek:self.queue.size error:NULL];
     NSArray<NSNumber *> *expected = @[@1, @2];
     XCTAssertEqualObjects(remainingElements, expected);
 }
 
 - (void)testRemoveDoesNothingWhenQueueIsEmpty {
     XCTAssertTrue(self.queue.isEmpty);
-    [self.queue pop:INT_MAX];
+    XCTAssertTrue([self.queue pop:INT_MAX error:NULL]);
     XCTAssertTrue(self.queue.isEmpty);
 }
 
@@ -164,37 +164,37 @@
 
 - (void)testPeekReturnsEmptyArrayWhenQueueIsEmpty {
     XCTAssertTrue(self.queue.isEmpty);
-    XCTAssertNil([self.queue peek]);
+    XCTAssertEqualObjects([self.queue peek:1 error:NULL], @[]);
 }
 
 - (void)testPeekReflectsObjectsAdded {
     NSUInteger amount = 10;
     NSNumber *expectedValue = @1;
     for (NSUInteger i = 0; i < amount; i++) {
-        [self.queue add:expectedValue];
+        XCTAssertTrue([self.queue add:expectedValue error:NULL]);
     }
 
-    NSArray<NSNumber *> *result = [self.queue peek:amount];
+    NSArray<NSNumber *> *result = [self.queue peek:amount error:NULL];
     for (NSUInteger i = 0; i < amount; i++) {
         XCTAssertEqualObjects(result[i], expectedValue);
     }
 }
 
 - (void)testPeekingGreaterThanSizeCapsToSize {
-    [self.queue add:@1];
-    NSArray<id> *result = [self.queue peek:INT_MAX];
+    XCTAssertTrue([self.queue add:@1 error:NULL]);
+    NSArray<id> *result = [self.queue peek:INT_MAX error:NULL];
     XCTAssertEqual(result.count, 1);
 }
 
 - (void)testClearRemovesAllObjects {
     XCTAssertEqual(self.queue.size, 0);
     for (NSUInteger i = 0; i < 1000; i++) {
-        [self.queue add:@1];
+        XCTAssertTrue([self.queue add:@1 error:NULL]);
     }
 
-    [self.queue clear];
+    XCTAssertTrue([self.queue clearAndReturnError:NULL]);
 
-    XCTAssertNil([self.queue peek]);
+    XCTAssertEqualObjects([self.queue peek:1 error:NULL], @[]);
     XCTAssertEqual(self.queue.size, 0);
 }
 

--- a/CassetteTests/CASInMemoryObjectQueueTests.m
+++ b/CassetteTests/CASInMemoryObjectQueueTests.m
@@ -28,7 +28,7 @@
     XCTAssertEqual(self.queue.size, 0);
 
     for (NSUInteger i = 0; i < 10; i++) {
-        [self.queue add:@1];
+        XCTAssertTrue([self.queue add:@1 error:NULL]);
     }
 
     XCTAssertEqual(self.queue.size, 10);
@@ -38,30 +38,30 @@
     XCTAssertEqual(self.queue.size, 0);
 
     for (int i = 0; i < 10; i++) {
-        [self.queue add:@1];
+        XCTAssertTrue([self.queue add:@1 error:NULL]);
     }
 
     for (int i = 9; i >= 0; i--) {
-        [self.queue pop];
+        XCTAssertTrue([self.queue pop:1 error:NULL]);
         XCTAssertEqual(self.queue.size, (NSUInteger) i);
     }
 }
 
 - (void)testCorrectElementIsRemovedWhenPopped {
     for (int i = 0; i < 3; i++) {
-        [self.queue add:[NSNumber numberWithInt:i]];
+        XCTAssertTrue([self.queue add:[NSNumber numberWithInt:i] error:NULL]);
     }
 
-    [self.queue pop];
+    XCTAssertTrue([self.queue pop:1 error:NULL]);
 
-    NSArray<NSNumber *> *remainingElements = [self.queue peek:self.queue.size];
+    NSArray<NSNumber *> *remainingElements = [self.queue peek:self.queue.size error:NULL];
     NSArray<NSNumber *> *expected = @[@1, @2];
     XCTAssertEqualObjects(remainingElements, expected);
 }
 
 - (void)testRemoveDoesNothingWhenQueueIsEmpty {
     XCTAssertTrue(self.queue.isEmpty);
-    [self.queue pop:INT_MAX];
+    XCTAssertTrue([self.queue pop:INT_MAX error:NULL]);
     XCTAssertTrue(self.queue.isEmpty);
 }
 
@@ -72,37 +72,37 @@
 
 - (void)testPeekReturnsEmptyArrayWhenQueueIsEmpty {
     XCTAssertTrue(self.queue.isEmpty);
-    XCTAssertNil([self.queue peek]);
+    XCTAssertEqualObjects([self.queue peek:1 error:NULL], @[]);
 }
 
 - (void)testPeekReflectsObjectsAdded {
     NSUInteger amount = 10;
     NSNumber *expectedValue = @1;
     for (NSUInteger i = 0; i < amount; i++) {
-        [self.queue add:expectedValue];
+        XCTAssertTrue([self.queue add:expectedValue error:NULL]);
     }
 
-    NSArray<NSNumber *> *result = [self.queue peek:amount];
+    NSArray<NSNumber *> *result = [self.queue peek:amount error:NULL];
     for (NSUInteger i = 0; i < amount; i++) {
         XCTAssertEqualObjects(result[i], expectedValue);
     }
 }
 
 - (void)testPeekingGreaterThanSizeCapsToSize {
-    [self.queue add:@1];
-    NSArray<id> *result = [self.queue peek:INT_MAX];
+    XCTAssertTrue([self.queue add:@1 error:NULL]);
+    NSArray<id> *result = [self.queue peek:INT_MAX error:NULL];
     XCTAssertEqual(result.count, 1);
 }
 
 - (void)testClearRemovesAllObjects {
     XCTAssertEqual(self.queue.size, 0);
     for (NSUInteger i = 0; i < 1000; i++) {
-        [self.queue add:@1];
+        XCTAssertTrue([self.queue add:@1 error:NULL]);
     }
 
-    [self.queue clear];
+    XCTAssertTrue([self.queue clearAndReturnError:NULL]);
 
-    XCTAssertNil([self.queue peek]);
+    XCTAssertEqualObjects([self.queue peek:1 error:NULL], @[]);
     XCTAssertEqual(self.queue.size, 0);
 }
 

--- a/CassetteTests/CASQueueFileTests.m
+++ b/CassetteTests/CASQueueFileTests.m
@@ -32,7 +32,7 @@
 
 - (void)tearDown {
     if (self.queueFile != nil) {
-        [self.queueFile clear];
+        XCTAssertTrue([self.queueFile clearAndReturnError:NULL]);
     }
 }
 
@@ -47,7 +47,7 @@
     NSUInteger expected = 10;
 
     for (NSUInteger i = 0; i < expected; i++) {
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
     }
 
     XCTAssertEqual(self.queueFile.size, expected);
@@ -61,11 +61,11 @@
     for (NSUInteger i = 0; i < numElements; i++) {
         NSString *stringToStore = [NSString stringWithFormat:expectedFormat, i];
         NSData *data = [stringToStore dataUsingEncoding:NSUTF8StringEncoding];
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
     }
 
     // Verify the data
-    NSArray<NSData *> *elements = [self.queueFile peek:numElements];
+    NSArray<NSData *> *elements = [self.queueFile peek:numElements error:NULL];
     XCTAssertEqual(elements.count, numElements);
     for (NSUInteger i = 0; i < numElements; i++) {
         NSData *data = elements[i];
@@ -77,31 +77,31 @@
 
 - (void)testRepeatedPeeksAreConsistent {
     NSData *data = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
-    [self.queueFile add:data];
+    XCTAssertTrue([self.queueFile add:data error:NULL]);
 
-    NSArray<NSData *> *array1 = [self.queueFile peek:1];
-    NSArray<NSData *> *array2 = [self.queueFile peek:1];
+    NSArray<NSData *> *array1 = [self.queueFile peek:1 error:NULL];
+    NSArray<NSData *> *array2 = [self.queueFile peek:1 error:NULL];
 
     XCTAssertEqualObjects(array1, array2);
 }
 
 - (void)testPeekDoesNotChangeSizeState {
     NSData *data = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
-    [self.queueFile add:data];
+    XCTAssertTrue([self.queueFile add:data error:NULL]);
 
     XCTAssertEqual(self.queueFile.size, 1);
-    __unused NSArray<NSData *> *array1 = [self.queueFile peek:1];
+    __unused NSArray<NSData *> *array1 = [self.queueFile peek:1 error:NULL];
     XCTAssertEqual(self.queueFile.size, 1);
 }
 
 - (void)testPeekingGreaterThanSizeIsSafe {
-    NSArray *result = [self.queueFile peek:INT_MAX];
+    NSArray *result = [self.queueFile peek:INT_MAX error:NULL];
     XCTAssertEqual(result.count, 0);
 }
 
 - (void)testPopDoesNothingWhenQueueIsEmpty {
     XCTAssertEqual(self.queueFile.size, 0);
-    [self.queueFile pop:INT_MAX];
+    XCTAssertTrue([self.queueFile pop:INT_MAX error:NULL]);
     XCTAssertEqual(self.queueFile.size, 0);
 }
 
@@ -109,11 +109,11 @@
     NSData *data = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
     NSUInteger numElements = 10;
     for (NSUInteger i = 0; i < numElements; i++) {
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
     }
     XCTAssertEqual(self.queueFile.size, numElements);
 
-    [self.queueFile pop:5];
+    XCTAssertTrue([self.queueFile pop:5 error:NULL]);
 
     NSUInteger expected = numElements = 5;
     XCTAssertEqual(self.queueFile.size, expected);
@@ -123,18 +123,19 @@
     NSUInteger numElements = 10;
     for (NSUInteger i = 0; i < numElements; i++) {
         NSData *data = [NSData dataWithBytes:&i length:sizeof(i)];
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
     }
 
     // Remove half the queue, to test whether the correct half was removed
     NSUInteger amountToRemove = 5;
-    [self.queueFile pop:amountToRemove];
+    XCTAssertTrue([self.queueFile pop:amountToRemove error:NULL]);
 
     // Verify the data
     NSUInteger expectedAmountRemaining = numElements - amountToRemove;
     XCTAssertEqual(self.queueFile.size, expectedAmountRemaining);
 
-    NSArray<NSData *> *elements = [self.queueFile peek:expectedAmountRemaining];
+    NSArray<NSData *> *elements = [self.queueFile peek:expectedAmountRemaining error:NULL];
+    XCTAssertEqual(elements.count, expectedAmountRemaining);
     for (NSUInteger i = 0; i < elements.count; i++) {
         NSUInteger coercedData;
         [elements[i] getBytes:&coercedData length:sizeof(coercedData)];
@@ -146,7 +147,7 @@
     NSData *data = [NSMutableData dataWithLength:4096];
     NSUInteger numElements = 10;
     for (NSUInteger i = 0; i < numElements; i++) {
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
     }
     XCTAssertEqual(self.queueFile.size, numElements);
 }
@@ -161,15 +162,16 @@
     NSUInteger numElements = 10;
     for (NSUInteger i = 0; i < numElements; i++) {
         NSData *data = [NSData dataWithBytes:&i length:sizeof(i)];
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
     }
 
     XCTAssertEqual(self.queueFile.size, originalSize + numElements);
 
-    [self.queueFile pop:numElements];
+    XCTAssertTrue([self.queueFile pop:numElements error:NULL]);
     XCTAssertEqual(self.queueFile.size, numElements);
 
-    NSArray<NSData *> *elements = [self.queueFile peek:numElements];
+    NSArray<NSData *> *elements = [self.queueFile peek:numElements error:NULL];
+    XCTAssertEqual(elements.count, numElements);
     for (NSUInteger i = 0; i < elements.count; i++) {
         NSUInteger coercedData;
         [elements[i] getBytes:&coercedData length:sizeof(coercedData)];
@@ -182,7 +184,8 @@
     NSUInteger numElementsToRemove = numElementsToStartWith / 2;
     NSArray<NSData *> * dataArray = [self triggerStressedFragmentation:numElementsToStartWith
                                                    numElementsToRemove:numElementsToRemove];
-    NSArray<NSData *> *elements = [self.queueFile peek:self.queueFile.size];
+    NSArray<NSData *> *elements = [self.queueFile peek:self.queueFile.size error:NULL];
+    XCTAssertEqual(elements.count, self.queueFile.size);
     for (NSUInteger i = 0; i < elements.count; i++) {
         XCTAssertEqualObjects(elements[(i + numElementsToRemove) % numElementsToStartWith],
                               dataArray[i]);
@@ -206,16 +209,16 @@
         for (NSUInteger j = 0; j < sizeOfEachElement; j++) {
             [data appendBytes:&i length:1];
         }
-        [self.queueFile add:data];
+        XCTAssertTrue([self.queueFile add:data error:NULL]);
         [dataArray addObject:data];
     }
 
     // At this point, buffer should be completely full.
     // To trigger fragmentation, let's pop a few elements and add them back in.
     // This will mean the head is now somewhere in the middle of the file, as well as the tail.
-    [self.queueFile pop:numElementsToRemove];
+    XCTAssertTrue([self.queueFile pop:numElementsToRemove error:NULL]);
     for (NSUInteger i = 0; i < numElementsToRemove; i++) {
-        [self.queueFile add:dataArray[i]];
+        XCTAssertTrue([self.queueFile add:dataArray[i] error:NULL]);
     }
 
     return dataArray;

--- a/README.md
+++ b/README.md
@@ -34,26 +34,32 @@ queue = [[CASInMemoryObjectQueue alloc] init];
 
 Add some data to the end of the queue.
 ```
-[queue add:@1];
+NSError *error;
+if ([queue add:@1 error:&error]) {
+  // Success
+} else {
+  NSLog(@"Error: %@", error);
+}
 ```
 
 Read data at the head of the queue.
 ```
-// Peek the eldest element.
-NSNumber *data = [queue peek];
+// Peek the eldest element. Note that -peek:error: on an empty queue
+// returns @[], but on error (e.g., I/O error) it returns nil.
+NSNumber *data = [queue peek:1 error:&error].firstObject;
 
 // Peek the eldest `n` elements.
-NSArray<NSNumber *> *data = [queue peek:n];
+NSArray<NSNumber *> *data = [queue peek:n error:&error];
 ```
 
 Remove processed elements.
 ```
 // Remove the eldest element.
-[queue pop];
+if ([queue pop:1 error:&error]) { ... }
 
 // Remove 'n' elements.
-[queue pop:n];
+if ([queue pop:n error:&error]) { ... }
 
 // Remove all elements.
-[queue clear];
+if ([queue clearAndReturnError:&error]) { ... }
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,13 +8,13 @@ pr:
     - master
 
 pool:
-  vmImage: macOS-10.14
+  vmImage: macOS-10.15
   demands: xcode
 
 variables:
   workspace: 'Cassette.xcworkspace'
   scheme: 'Cassette'
-  xcodeVersion: '10'
+  xcodeVersion: '12'
 
 steps:
 - task: CocoaPods@0
@@ -39,5 +39,4 @@ steps:
     scheme: $(scheme)
     xcodeVersion: $(xcodeVersion)
     destinationPlatformOption: 'iOS'
-    destinationSimulators: 'iPhone X'
     publishJUnitResults: true


### PR DESCRIPTION
This PR fixes #7 .

Previously, I/O and serialization/deserialization errors were silently
swallowed.

This commit makes use of the NSFileHandle APIs on iOS 13 and later to
perform filesystem operations and propagate the errors to the caller.

The following APIs are now deprecated in favor of the variants that take
a (nullable) `NSError **`:

```
-[CASQueueFile add:]
-[CASQueueFile peek:]
-[CASQueueFile pop:]
-[CASQueueFile clear]
-[CASObjectQueue add:]
-[CASObjectQueue peek:]
-[CASObjectQueue pop:]
-[CASObjectQueue clear]
```

In addition, the two convenience methods `-peek` and `-pop` to access
a single element are deprecated since there is no way to distinguish
an empty queue from an error:

```
-[CASObjectQueue peek]
-[CASObjectQueue pop]
```

Use `-peek:error:` and `-pop:error:` instead, and call `-firstObject`
on the result if you don't need to distinguish an empty queue from an
error.

I also bumped the Azure Xcode version to Xcode 12 so CI builds with the new APIs.