### PR TITLE
Support -Woverriding-method-mismatch.

### DIFF
--- a/Cassette.xcodeproj/project.pbxproj
+++ b/Cassette.xcodeproj/project.pbxproj
@@ -706,6 +706,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = "-Woverriding-method-mismatch";
 			};
 			name = Debug;
 		};
@@ -749,6 +750,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = "-Woverriding-method-mismatch";
 			};
 			name = Release;
 		};

--- a/Cassette/CASObjectQueue.m
+++ b/Cassette/CASObjectQueue.m
@@ -18,11 +18,11 @@
     return NO;
 }
 
-- (void)add:(id)data {
+- (void)add:(id<NSCoding>)data {
     [self add:data error:NULL];
 }
 
-- (BOOL)add:(id)data error:(NSError * __autoreleasing * _Nullable)error {
+- (BOOL)add:(id<NSCoding>)data error:(NSError * __autoreleasing * _Nullable)error {
     return [self addElements:@[data] error:error];
 }
 


### PR DESCRIPTION
Add to project -Woverriding-method-mismatch.
Clean up code to compile cleanly.