### PR TITLE
Update to minimum supported deployment target: iOS 9.0

### DIFF
--- a/Cassette.podspec
+++ b/Cassette.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.public_header_files = 'Cassette/*.h'
   spec.source_files        = 'Cassette/*.{h,m}'
 
-  spec.ios.deployment_target = '8.0'
+  spec.ios.deployment_target = '9.0'
   spec.osx.deployment_target = '10.11'
 
   spec.requires_arc     = true


### PR DESCRIPTION
When building my project with `Cassette`, I see the following warning in Xcode 13:
> Showing All Issues
> /.../ios/Pods/Pods.xcodeproj The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.4.99.

This change updates the iOS deployment target to `9.0` to match the Xcode minimum.