### PR TITLE
[Cassette] Fix crash when queue file is corrupted/too short

### DIFF
--- a/Cassette/CASError.h
+++ b/Cassette/CASError.h
@@ -16,7 +16,8 @@ FOUNDATION_EXPORT NSString *const CASErrorDomain;
 FOUNDATION_EXPORT const int CASErrorCode;
 
 typedef NS_ENUM(NSInteger, CASErrorType) {
-    CASErrorFileInitialization
+    CASErrorFileInitialization,
+    CASErrorReadErrorFileTooShort,
 };
 
 @interface CASError : NSObject

--- a/Cassette/CASError.m
+++ b/Cassette/CASError.m
@@ -36,6 +36,9 @@ const int CASErrorCode = -7493;
         case CASErrorFileInitialization:
             desc = @"Could not initialize file.";
             break;
+        case CASErrorReadErrorFileTooShort:
+            desc = @"Read error (file too short)";
+            break;
         default:
             desc = @"Unknown Cassette error. Developer likely mistakenly applied this as a Cassette error.";
             break;


### PR DESCRIPTION
Previously, `-[CASQueueFile queueFileWithPath:error:]` would crash if provided a file whose contents were too short to fit the header.

This could happen if the queue file was written when the user was out of disk space, or if it was truncated to zero length for any reason (disk corruption, etc.)

Sample crash:

```
NSRangeException reason *** -[_NSZeroData getBytes:range:]: range {0, 4} exceeds data length 0

0x000000018f4bb2e0 (libobjc.A.dylib + 0x000172e0)	objc_exception_throw
0x0000000190db63dc (Foundation + 0x0004e3dc)	-[NSData(NSData) getBytes:range:]
0x000000010635036c (AppName - CASQueueFile.m: 779)	readUnsignedInt
0x000000010635036c (AppName - CASQueueFile.m: 427)	-[CASQueueFile readElement:error:]
0x000000010634f6d8 (AppName - CASQueueFile.m: 134)	+[CASQueueFile queueFileWithPath:error:]
0x000000010634e900 (AppName - CASFileObjectQueue.m: 47)	-[CASFileObjectQueue initWithAbsolutePath:serializer:error:]
0x000000010634e874 (AppName - CASFileObjectQueue.m: 42)	-[CASFileObjectQueue initWithAbsolutePath:error:]
```

This fixes the crash and adds a test to reproduce the issue.

Fixes #38