### PR TITLE
[Cassette] Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+IndentWidth: 4


### PR DESCRIPTION
This CL adds a `.clang-format` file to apply the current Cassette style of 4 space indents, so tools like `git clang-format` work correctly.
